### PR TITLE
fix: Make tmux status plugins work correctly

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,5 +1,3 @@
-source "$HOME/.dots/tmux/plugins.tmux"
-
 # set terminal
 set -g default-terminal "xterm-256color"
 
@@ -55,3 +53,4 @@ set-option -g status-left "[#S]"
 set-option -g status-right "\"#(hostname -s)\" %H:%M %d-%b-%y"
 
 source "$HOME/.dots/tmux/theme.tmux"
+source "$HOME/.dots/tmux/plugins.tmux"


### PR DESCRIPTION
By requiring the file on the wrong order, tmux plugins which need to
work on the `status-{left, right}` are actually getting a outdated version of
the variable to parse.

Related to: tmux-plugins/tmux-battery#21

Thanks @bruno- for the help on finding this issue.
