### PR TITLE
fix: Remove invalid cask

### DIFF
--- a/osx/Brewfile
+++ b/osx/Brewfile
@@ -12,7 +12,6 @@ tap 'juanibiapina/zas'
 
 # Install Apps
 cask_args appdir: '/Applications'
-cask '1password3'
 cask 'adium'
 cask 'airmail-beta'
 cask 'alfred'


### PR DESCRIPTION
There is no more 1password3 cask formula, only 1password
Prevent error: Kernel.exit
